### PR TITLE
fix: prevent `undefined` in generated text

### DIFF
--- a/_includes/scripts-lorem.html
+++ b/_includes/scripts-lorem.html
@@ -62,7 +62,7 @@
     if (param) {
 
         var lorem = lorems[Math.floor(Math.random()*lorems.length)];
-        var loremGen = [];
+        var loremGen = [''];
         var multiPara = '';
         var wordCount = window.location.search.substring(1).split("&")[0].split("=")[1];
         var paraCount = window.location.search.substring(1).split("&")[1].split("=")[1];


### PR DESCRIPTION
![screenshot](https://cloud.githubusercontent.com/assets/687325/13217705/8028f72c-d99f-11e5-9daa-baf1ff2a572b.png)

Undefined is showing up on the generated file if paraCount is 0 (the default value of paragraph count)
